### PR TITLE
feat: conversion between votables's coosys and astropy built in frames

### DIFF
--- a/astropy/io/votable/data/ivoa-vocalubary_refframe-v20220222.json
+++ b/astropy/io/votable/data/ivoa-vocalubary_refframe-v20220222.json
@@ -1,0 +1,182 @@
+{
+  "uri": "http://www.ivoa.net/rdf/refframe",
+  "flavour": "RDF Class",
+  "terms": {
+    "EQUATORIAL": {
+      "label": "Equatorial",
+      "description": "Umbrella term of all equatorial frames.  Only use for old, pre-FK4 equatorial coordinates.",
+      "wider": [],
+      "narrower": [
+        "geo_app",
+        "ICRS",
+        "FK4",
+        "FK5",
+        "eq_FK4",
+        "eq_FK5"
+      ]
+    },
+    "geo_app": {
+      "label": "Geocentric Apparent Positions",
+      "description": "Positions given as observed by a fictitious observer at the Earth's centre for the equator of observation.",
+      "wider": [
+        "EQUATORIAL"
+      ],
+      "narrower": []
+    },
+    "ICRS": {
+      "label": "ICRS",
+      "description": "International Celestial Reference System as defined by 1998AJ....116..516M.",
+      "wider": [
+        "EQUATORIAL"
+      ],
+      "narrower": []
+    },
+    "FK4": {
+      "label": "FK4",
+      "description": "Positions based on the 4th Fundamental Katalog. If no equinox is defined with this frame, assume B1950.0.",
+      "wider": [
+        "EQUATORIAL"
+      ],
+      "narrower": []
+    },
+    "FK5": {
+      "label": "FK5",
+      "description": "Positions based on the 5th Fundamental Katalog. If no equinox is defined with this frame, assume J2000.0.  Applications not requiring extremely high precision can identify FK5 at J2000 with ICRS.",
+      "wider": [
+        "EQUATORIAL"
+      ],
+      "narrower": []
+    },
+    "eq_FK4": {
+      "label": "FK4",
+      "description": "Old VOTable COOSYS term for FK4.",
+      "useInstead": "FK4",
+      "deprecated": "",
+      "wider": [
+        "EQUATORIAL"
+      ],
+      "narrower": []
+    },
+    "eq_FK5": {
+      "label": "FK5",
+      "description": "Old VOTable COOSYS term for FK5.",
+      "deprecated": "",
+      "useInstead": "FK5",
+      "wider": [
+        "EQUATORIAL"
+      ],
+      "narrower": []
+    },
+    "ECLIPTIC": {
+      "label": "Ecliptic",
+      "description": "Ecliptic coordinates; the ecliptic of J2000.0 is assumed.",
+      "wider": [],
+      "narrower": [
+        "ecl_FK4",
+        "ecl_FK5"
+      ]
+    },
+    "ecl_FK4": {
+      "label": "Ecliptic (FK4)",
+      "description": "Old VOTable COOSYS term ecliptic coordinates for the FK4 ecliptic (of B1950.0).",
+      "wider": [
+        "ECLIPTIC"
+      ],
+      "narrower": []
+    },
+    "ecl_FK5": {
+      "label": "Ecliptic (FK5)",
+      "description": "Old VOTable COOSYS term ecliptic coordinates for the FK5 ecliptic (of J2000.0).",
+      "useInstead": "ECLIPTIC",
+      "deprecated": "",
+      "wider": [
+        "ECLIPTIC"
+      ],
+      "narrower": []
+    },
+    "GENERIC_GALACTIC": {
+      "label": "Galactic",
+      "description": "Umbrella term for Galactic coordinates.  If at all possible, use a more specific term, as historically, many different conventions have been in use.",
+      "wider": [],
+      "narrower": [
+        "GALACTIC_I",
+        "GALACTIC",
+        "galactic"
+      ]
+    },
+    "GALACTIC_I": {
+      "label": "Old Galactic",
+      "description": "Old, pre-1958, Galactic coordinates.  See 1960MNRAS.121..123B for details.",
+      "wider": [
+        "GENERIC_GALACTIC"
+      ],
+      "narrower": []
+    },
+    "GALACTIC": {
+      "label": "Galactic",
+      "description": "Galactic coordinates, modern definition: Pole at precisely FK4 B1950 192.25, 27.4, origin at approximately FK4 B1950 265.55, -28.92.  See 1960MNRAS.121..123B for details.",
+      "wider": [
+        "GENERIC_GALACTIC"
+      ],
+      "narrower": []
+    },
+    "galactic": {
+      "label": "Galactic",
+      "description": "Old VOTable COOSYS term for GALACTIC.",
+      "useInstead": "GALACTIC",
+      "deprecated": "",
+      "wider": [
+        "GENERIC_GALACTIC"
+      ],
+      "narrower": []
+    },
+    "SUPER_GALACTIC": {
+      "label": "Supergalactic",
+      "description": "Supergalactic coordinates (pole at GALACTIC 47.37, +6.32, origin at GALACTIC 137.37, 0.",
+      "wider": [],
+      "narrower": []
+    },
+    "supergalactic": {
+      "label": "Supergalactic",
+      "description": "Old VOTable COOSYS term for SUPER_GALACTIC",
+      "deprecated": "",
+      "useInstead": "SUPER_GALACTIC",
+      "wider": [],
+      "narrower": []
+    },
+    "AZ_EL": {
+      "label": "Azimuth/elevation",
+      "description": "Local azimuth and elevation. (Ground-based observations; Azimuth from North through East.)",
+      "wider": [],
+      "narrower": []
+    },
+    "BODY": {
+      "label": "Body Coordinates",
+      "description": "Generic bodycentric coordinates. Data annotated in this way cannot be automatically combined with any other data.  Use or create more specific terms if at all possible.",
+      "wider": [],
+      "narrower": []
+    },
+    "UNKNOWN": {
+      "label": "Unknown reference frame",
+      "description": "Unknown reference frame. Only to be used as a last resort or for simulations. Data annotated in this way cannot be automatically combined with any other data.",
+      "wider": [],
+      "narrower": []
+    },
+    "xy": {
+      "label": "Unknown reference frame",
+      "description": "Old VOTable COOSYS term for UNKNOWN",
+      "deprecated": "",
+      "useInstead": "UNKNOWN",
+      "wider": [],
+      "narrower": []
+    },
+    "barycentric": {
+      "label": "ICRS/Bary",
+      "description": "Old VOTable COOSYS term indicating ICRS at BARYCENTER reference position.  In the modern VO, refpos and refframe are no longer represented together.  Do not use this any more.",
+      "useInstead": "ICRS",
+      "deprecated": "",
+      "wider": [],
+      "narrower": []
+    }
+  }
+}

--- a/astropy/io/votable/tests/test_coosys.py
+++ b/astropy/io/votable/tests/test_coosys.py
@@ -3,8 +3,10 @@ import io
 
 import pytest
 
+from astropy.coordinates import FK4, FK5, ICRS, AltAz, Galactic, Supergalactic
 from astropy.io.votable.exceptions import E16, W27, W57
 from astropy.io.votable.table import parse
+from astropy.io.votable.tree import CooSys
 from astropy.utils.data import get_pkg_data_filename
 
 COOSYS_TEMPLATE = """<?xml version="1.0" encoding="UTF-8"?>
@@ -55,25 +57,21 @@ def test_accept_refposition():
 
 
 def test_coosys_system():
-    """
-    Check that prior to v1.5, an error is issues for a system not in the hard-coded list.
-    With 1.5 the vocabulary is external and we're not checking that yet.
-    """
     for version, system, expected_warning in [
         ("1.4", "ICRS", None),
         ("1.4", "supergalactic", None),
         ("1.4", "InvalidSystem", E16),
         ("1.5", "ICRS", None),
         ("1.5", "supergalactic", None),
-        ("1.5", "InvalidSystem", None),
+        ("1.5", "InvalidSystem", E16),
     ]:
         xml_string = COOSYS_SYSTEM_TEMPLATE.format(version, system)
         input = io.BytesIO(bytes(xml_string, "utf-8"))
         if expected_warning is not None:
             with pytest.warns(expected_warning):
-                vot = parse(input, verify="warn")
+                parse(input, verify="warn")
         else:
-            vot = parse(input, verify="warn")
+            parse(input, verify="warn")
 
 
 def _coosys_tests(votable):
@@ -109,3 +107,33 @@ def test_coosys_roundtrip():
     bio.seek(0)
     votable = parse(bio)
     _coosys_tests(votable)
+
+
+test_to_astropy_frame = [
+    ("ICRS", None, None, ICRS()),
+    ("FK4", "B1950", "B1950", FK4(equinox="B1950")),
+    ("FK5", "J2000", None, FK5(equinox="J2000")),
+    ("eq_FK4", "B1950", "B1950", FK4(equinox="B1950")),
+    ("eq_FK5", "J2000", None, FK5(equinox="J2000")),
+    ("GALACTIC", None, None, Galactic()),
+    ("galactic", None, None, Galactic()),
+    ("SUPER_GALACTIC", None, None, Supergalactic()),
+    ("supergalactic", None, None, Supergalactic()),
+    ("AZ_EL", None, "J2020", AltAz()),
+]
+
+
+@pytest.mark.parametrize("system,equinox,epoch,expected", test_to_astropy_frame)
+def test_coosys_to_astropy_frame_and_time(system, equinox, epoch, expected):
+    coosys = CooSys(equinox=equinox, epoch=epoch, system=system)
+    assert coosys.to_astropy_frame() == expected
+
+
+def test_coosys_to_astropy_frame_error():
+    with pytest.raises(
+        ValueError,
+        match=(
+            "There is no direct correspondence between 'BODY' and an astropy frame.*"
+        ),
+    ):
+        CooSys(system="BODY").to_astropy_frame()


### PR DESCRIPTION
Recreated from original PR: https://github.com/astropy/astropy/pull/17999

Hi astropy maintainers!

### Description

This PR does:

- add a check for coosys systems according to http://www.ivoa.net/rdf/refframe (was a TODO in the comments)
- add a method to convert a CooSys object into an astropy built in frame

This is of particular interest when reading VOTables, see for example this workflow:

```python
from io import BytesIO
from astropy.io.votable import parse as parse_votable
import requests

url = "https://vizier.cds.unistra.fr/viz-bin/votable?-s...